### PR TITLE
Workflows: remove upload from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Run tests
         run: |
             meson test -C build --wrapper="xvfb-run --auto-servernum --server-num=1" || ([[ -f /home/runner/work/live-chart/live-chart/build/meson-logs/testlog-xvfb-run.txt ]] && cat /home/runner/work/live-chart/live-chart/build/meson-logs/testlog-xvfb-run.txt && exit 1)
-      - name: Send coverage report
-        run: bash <(curl -s https://codecov.io/bash)
 
   lint:
     name: Lint


### PR DESCRIPTION
We don't have a token for this service so it always fails